### PR TITLE
Add basic VFIO unit tests

### DIFF
--- a/src/fam.rs
+++ b/src/fam.rs
@@ -17,7 +17,7 @@ fn vec_with_size_in_bytes<T: Default>(size_in_bytes: usize) -> Vec<T> {
 /// pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>);
 /// #[repr(C)]
 /// struct Foo {
-///    some_data: ControlMessageHeader,
+///    some_data: u32,
 ///    entries: __IncompleteArrayField<u32>,
 /// }
 /// ```


### PR DESCRIPTION
Some unit test may require interactive with real devices,
we ignore them by default.

Fixes #2