### PR TITLE
Update Readme and add basic example

### DIFF
--- a/LICENSE-BSD-3-Clause
+++ b/LICENSE-BSD-3-Clause
@@ -1,0 +1,27 @@
+// Copyright 2017 The Chromium OS Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,40 @@
-# Crate Name
+# vfio-ioctls
 
-## Design
+The vfio-ioctls crate provide safe wrappers over the
+[VFIO API](https://www.kernel.org/doc/Documentation/vfio.txt), a set of
+ioctls are used to expose direct device access to userspace in a secure,
+IOMMU protected environment. The ioctls include create and configure
+VFIO container, group, device and IOMMU related objects on Linux.
+The vfio-ioctls crate provide three structures and a trait to access
+these ioctls:
+- `VfioContainer` - wrapper over a VFIO container object
+- `VfioDevice` - to access underline hardware devices
+- `VfioDmaMapping` - implements the ExternalDmaMapping trait
+- `ExternalDmaMapping` - Trait for triggering the DMA mapping update
+related to an external device
 
-TODO: This section should have a high-level design of the crate.
+For further details, please check the code documentation.
 
-Some questions that might help in writing this section:
-- What is the purpose of this crate?
-- What are the main components of the crate? How do they interact which each
-  other?
+## Supported Platform
+
+- x86_64
 
 ## Usage
 
-TODO: This section describes how the crate is used.
+Add the following to your `Cargo.toml`:
+```toml
+vfio-ioctls = { git = "https://github.com/cloud-hypervisor/vfio-ioctls", branch = "ch" }
+```
 
-Some questions that might help in writing this section:
-- What traits do users need to implement?
-- Does the crate have any default/optional features? What is each feature
-  doing?
-- Is this crate used by other rust-vmm components? If yes, how?
-
-## Examples
-
-TODO: Usage examples.
-
+Then you can import the structs or trait where you need them:
 ```rust
-use my_crate;
+// Import the required structs
+use vfio_ioctls::{VfioContainer, VfioDevice, VfioDmaMapping};
 
-...
+// Import the required trait
+use vfio_ioctls::ExternalDmaMapping;
 ```
 
 ## License
 
-**!!!NOTICE**: The BSD-3-Clause license is not included in this template.
-The license needs to be manually added because the text of the license file
-also includes the copyright. The copyright can be different for different
-crates. If the crate contains code from CrosVM, the crate must add the
-CrosVM copyright which can be found
-[here](https://chromium.googlesource.com/chromiumos/platform/crosvm/+/master/LICENSE).
-For crates developed from scratch, the copyright is different and depends on
-the contributors.
+This code is licensed under Apache-2.0 or BSD-3-Clause.

--- a/src/vfio_device.rs
+++ b/src/vfio_device.rs
@@ -1081,7 +1081,8 @@ mod tests {
 
         let device = VfioDevice::new(
             Path::new(VFIO_DEVICE_PATH),
-            container
+            container,
+            true
         ).expect("Failed to create VFIO device");
 
         assert!(device.as_raw_fd() > 0);

--- a/src/vfio_device.rs
+++ b/src/vfio_device.rs
@@ -132,6 +132,24 @@ impl VfioContainer {
     ///
     /// # Arguments
     /// * `device_fd`: file handle of the KVM VFIO device.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use kvm_bindings::kvm_device_type_KVM_DEV_TYPE_VFIO;
+    /// # use kvm_ioctls::Kvm;
+    /// # use std::sync::Arc;
+    /// # use vfio_ioctls::VfioContainer;
+    /// let kvm = Kvm::new().unwrap();
+    /// let vm = kvm.create_vm().unwrap();
+    /// let mut vfio_device = kvm_bindings::kvm_create_device {
+    ///     type_: kvm_device_type_KVM_DEV_TYPE_VFIO,
+    ///     fd: 0,
+    ///     flags: 0,
+    /// };
+    /// let fd = vm.create_device(&mut vfio_device).unwrap();
+    /// let container = VfioContainer::new(Arc::new(fd)).unwrap();
+    /// ```
     pub fn new(device_fd: Arc<DeviceFd>) -> Result<Self> {
         let container = OpenOptions::new()
             .read(true)


### PR DESCRIPTION
Cargo test will build and run example code by default, for most of vfio-ioctls public functions are required to interactive with real hardware device, then we only add the example for vfio container, other parts we may refer the unit test.
