### PR TITLE
vfio_device: Use the vm-memory crate with dirty-page tracking

### DIFF
--- a/src/vfio_device.rs
+++ b/src/vfio_device.rs
@@ -21,13 +21,15 @@ use kvm_bindings::{
 use kvm_ioctls::DeviceFd;
 use log::{debug, error, warn};
 use vfio_bindings::bindings::vfio::*;
-use vm_memory::{Address, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+use vm_memory::{bitmap::AtomicBitmap, Address, GuestMemory, GuestMemoryRegion};
 use vmm_sys_util::errno::Error as SysError;
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::ioctl::*;
 
 use crate::fam::vec_with_array_field;
 use crate::vfio_ioctls::*;
+
+type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
 
 #[allow(missing_docs)]
 #[derive(Debug)]


### PR DESCRIPTION
We need to patch the vfio-ioctl crate with the updated `GuestMemoryMmap` struct, so that it can work with the custom vm-memory crate ([our fork](https://github.com/cloud-hypervisor/vm-memory/tree/ch)) that has the dirty-page-tracking capability.

Signed-off-by: Bo Chen <chen.bo@intel.com>